### PR TITLE
dse-mesos-storage-url-fix

### DIFF
--- a/repo/packages/D/dse/0/config.json
+++ b/repo/packages/D/dse/0/config.json
@@ -72,7 +72,7 @@
           "storage": {
             "type": "string",
             "description": "State storage path. See --storage option",
-            "default": "zk:/dse-mesos"
+            "default": "zk:master.mesos:2181/dse-mesos"
           },
           "jre": {
             "type": "string",


### PR DESCRIPTION
Changed storage url to use master.mesos as zk host. 
Previously was localhost. This did not work on clusters where ZK is not installed on each node.
Please merge.
